### PR TITLE
Component placement classes

### DIFF
--- a/docs-sphinx/_static/iframes/asm-build-cycle/generate.py
+++ b/docs-sphinx/_static/iframes/asm-build-cycle/generate.py
@@ -104,7 +104,7 @@ class Thing(cqparts.Assembly):
         coords = self.components['cyl'].world_coords - self.components['pla'].world_coords
         # apply that to the "cutout" we want to subtract from the plate
         cutout = coords + self.components['cyl'].cutaway
-        self.components['pla'].local_obj = self.components['pla'].local_obj.cut(cutout)
+        self.components['pla'].obj = self.components['pla'].obj.cut(cutout)
 
 
 # -------------------------- Multiple Cycles --------------------------

--- a/docs-sphinx/_static/iframes/biscuit/generate.py
+++ b/docs-sphinx/_static/iframes/biscuit/generate.py
@@ -176,10 +176,10 @@ class BiscuitFastener(Fastener):
             ])
 
             # Move biscuit relative to altered part's local coordinates, then
-            # alter the part's local_obj.
+            # alter the part's local obj.
             for part in effected_parts:
                 biscuit_coordsys = biscuit.world_coords - part.world_coords
-                part.local_obj = part.local_obj.cut(biscuit_coordsys + biscuit_cutter)
+                part.obj = part.obj.cut(biscuit_coordsys + biscuit_cutter)
 
 
 # ------------------- Corner Assembly -------------------

--- a/docs-sphinx/_static/iframes/easy-install/generate.py
+++ b/docs-sphinx/_static/iframes/easy-install/generate.py
@@ -327,12 +327,12 @@ class EasyInstallFastener(Fastener):
             # screw : cut from all effected parts
             for effect in self.evaluator.eval:
                 screw_coordsys = screw.world_coords - effect.part.world_coords
-                effect.part.local_obj = effect.part.local_obj.cut(screw_coordsys + screw_cutter)
+                effect.part.obj = effect.part.obj.cut(screw_coordsys + screw_cutter)
 
             # anchor : all but last piece
             for effect in self.evaluator.eval[:-1]:
                 anchor_coordsys = anchor.world_coords - effect.part.world_coords
-                effect.part.local_obj = effect.part.local_obj.cut(anchor_coordsys + anchor_cutter)
+                effect.part.obj = effect.part.obj.cut(anchor_coordsys + anchor_cutter)
 
 
 

--- a/docs-sphinx/_static/iframes/parts/generate.py
+++ b/docs-sphinx/_static/iframes/parts/generate.py
@@ -69,9 +69,9 @@ class JoinedWheel(cqparts.Part):
         wheel_l = Wheel(radius=self.l_radius, width=self.l_width)
         wheel_r = Wheel(radius=self.r_radius, width=self.r_width)
         # Union them with the axle solid
-        obj = obj.union(wheel_l.local_obj)
+        obj = obj.union(wheel_l.obj)
         obj = obj.union(
-            wheel_r.local_obj.mirror('XY') \
+            wheel_r.obj.mirror('XY') \
                 .translate((0, 0, self.axle_length))
         )
         return obj
@@ -79,7 +79,7 @@ class JoinedWheel(cqparts.Part):
 joined_wheel = JoinedWheel(
     r_radius=80, l_width=20, axle_diam=30,
 )
-joined_wheel.local_obj
+joined_wheel.obj
 
 
 # ------------------- Red Box -------------------

--- a/docs-sphinx/_static/iframes/toy-car/generate.py
+++ b/docs-sphinx/_static/iframes/toy-car/generate.py
@@ -140,12 +140,12 @@ class WheeledAxle(cqparts.Assembly):
         axle = self.components['axle']
         left_wheel = self.components['left_wheel']
         right_wheel = self.components['right_wheel']
-        local_obj = part.local_obj
-        local_obj = local_obj \
+        obj = part.obj
+        obj = obj \
             .cut((axle.world_coords - part.world_coords) + axle.get_cutout()) \
             .cut((left_wheel.world_coords - part.world_coords) + left_wheel.get_cutout(self.wheel_clearance)) \
             .cut((right_wheel.world_coords - part.world_coords) + right_wheel.get_cutout(self.wheel_clearance))
-        part.local_obj = local_obj
+        part.obj = obj
 
 
 # ------------------- Car Assembly -------------------

--- a/docs-sphinx/cqparts/assembly-build-cycle.rst
+++ b/docs-sphinx/cqparts/assembly-build-cycle.rst
@@ -177,7 +177,7 @@ And finally, lets combine the two to fully utilise a single build cycle.
             coords = self.components['cyl'].world_coords - self.components['pla'].world_coords
             # apply that to the "cutout" we want to subtract from the plate
             cutout = coords + self.components['cyl'].cutaway
-            self.components['pla'].local_obj = self.components['pla'].local_obj.cut(cutout)
+            self.components['pla'].obj = self.components['pla'].obj.cut(cutout)
 
 I got a bit lazy with the parameters there; ``Thing`` doesn't take any.
 

--- a/docs-sphinx/cqparts/constraints.rst
+++ b/docs-sphinx/cqparts/constraints.rst
@@ -99,7 +99,7 @@ We can only know what ``C`` is if we know the values of both ``A`` and ``B``.
         @property
         def mate_top(self):
             return Mate(self, CoordSystem.from_plane(
-                self.local_obj.faces(">Z").workplane().plane
+                self.obj.faces(">Z").workplane().plane
             ))
 
     class Thing(Assembly):

--- a/docs-sphinx/cqparts/part-build-cycle.rst
+++ b/docs-sphinx/cqparts/part-build-cycle.rst
@@ -55,43 +55,43 @@ So then when we simply create an instance...
         x = 20
 
 
-Getting ``local_obj``
+Getting ``obj``
 ------------------------
 
-When a *part's* ``local_obj`` is requested, the instance's
+When a *part's* ``obj`` is requested, the instance's
 :meth:`make() <Part.make>` result is returned.
 
 Note that in the above test, the ``print`` statement in ``make()`` doesn't show.
-However, when we request ``local_obj``...
+However, when we request ``obj``...
 
 .. doctest::
 
     >>> box = Box(x=15)
     initializing parameters...
         x = 15
-    >>> obj1 = box.local_obj
+    >>> obj1 = box.obj
     running make()...
-    >>> obj2 = box.local_obj
+    >>> obj2 = box.obj
 
 
 However nothing is printed on the 2nd call. This is because the result is
-buffered, so when ``local_obj`` is requested a second time, it is
+buffered, so when ``obj`` is requested a second time, it is
 not re-made.
 
 Most uses of a :class:`Part` will get the local object by referencing
-``local_obj``, but you can forcefully remake the object in 2 ways:
+``obj``, but you can forcefully remake the object in 2 ways:
 
 .. doctest::
 
     >>> box = Box()
     initializing parameters...
         x = 10
-    >>> obj = box.local_obj
+    >>> obj = box.obj
     running make()...
 
-    >>> # 1) set local_obj to None
-    >>> box.local_obj = None
-    >>> obj = box.local_obj
+    >>> # 1) set obj to None
+    >>> box.obj = None
+    >>> obj = box.obj
     running make()...
 
     >>> # 2) call make() explicitly
@@ -106,7 +106,7 @@ However you shouldn't need to do this.
 
 If :meth:`world_coords <Component.world_coords>` has been set, getting
 :meth:`world_obj <Part.world_obj>` will create a copy of
-:meth:`local_obj <Part.local_obj>` that has been transformed to
+:meth:`obj <Part.obj>` that has been transformed to
 :meth:`world_coords <Component.world_coords>`.
 
 That is to say that it is translated, and rotated so the object's local
@@ -129,7 +129,7 @@ setting :meth:`world_coords <Component.world_coords>`.
 .. doctest::
 
     >>> box = Box()
-    >>> box.local_obj.val().BoundingBox().ymin
+    >>> box.obj.val().BoundingBox().ymin
     -5.0
 
     >>> # world_obj is None when the part does not have its world_coords
@@ -146,15 +146,15 @@ setting :meth:`world_coords <Component.world_coords>`.
     15.0
 
 
-Changing ``local_obj`` or ``world_coords``
+Changing ``obj`` or ``world_coords``
 --------------------------------------------------
 
-If :meth:`local_obj <Part.local_obj>` or
+If :meth:`obj <Part.obj>` or
 :meth:`world_coords <Component.world_coords>` is changed,
 :meth:`world_obj <Part.world_obj>` is reset.
 
 Then when :meth:`world_obj <Part.world_obj>` is requested again,
-:meth:`local_obj <Part.local_obj>` is copied and moved,
+:meth:`obj <Part.obj>` is copied and moved,
 just as it is explained above.
 
 So the obvious thing to do now is to drill a hole through the box... right?
@@ -165,14 +165,14 @@ So the obvious thing to do now is to drill a hole through the box... right?
     >>> box.world_coords = CoordSystem(origin=(0,20,0))
     >>> len(box.world_obj.val().Faces())
     6
-    >>> box.local_obj = box.local_obj.faces(">Z").hole(2)
+    >>> box.obj = box.obj.faces(">Z").hole(2)
     >>> len(box.world_obj.val().Faces())
     7
 
-Note that we changed :meth:`local_obj <Part.local_obj>`, but we tested the number of faces on
+Note that we changed :meth:`obj <Part.obj>`, but we tested the number of faces on
 :meth:`world_obj <Part.world_obj>`. So we can conclude from this that when any changes are
-made to the :meth:`local_obj <Part.local_obj>`, the
-:meth:`world_obj <Part.world_obj>` is re-created using :meth:`local_obj <Part.local_obj>`
+made to the :meth:`obj <Part.obj>`, the
+:meth:`world_obj <Part.world_obj>` is re-created using :meth:`obj <Part.obj>`
 as reference.
 
 Let's try the same thing by changing :meth:`world_obj <Part.world_obj>`:
@@ -182,14 +182,14 @@ Let's try the same thing by changing :meth:`world_obj <Part.world_obj>`:
     >>> box = Box()
     >>> box.world_coords = CoordSystem(origin=(0,20,0))
     >>> box.world_obj = box.world_obj.faces(">Z").hole(2) # doctest: +SKIP
-    ValueError: can't set world_obj directly, set local_obj instead
+    ValueError: can't set world_obj directly, set obj instead
 
 We get an exception instead
 
 .. warning::
 
     :meth:`world_obj <Part.world_obj>` cannot be changed directly, but it can be
-    changed indirectly via :meth:`local_obj <Part.local_obj>`.
+    changed indirectly via :meth:`obj <Part.obj>`.
 
 **But Why?**: This is to avoid bad practices that encourage accumulated errors; if
 the part can only be modified in its native coordinates, there is no possibility
@@ -197,7 +197,7 @@ of accumulated numerical error.
 
 .. note::
 
-    Remember: when changing the :meth:`local_obj <Part.local_obj>`, if your
+    Remember: when changing the :meth:`obj <Part.obj>`, if your
     alterations are based on world coordinates, you must convert back to the
     object's local coordinates before the changes will match your expectations.
 

--- a/docs-sphinx/cqparts_fasteners/biscuit/fastener.rst
+++ b/docs-sphinx/cqparts_fasteners/biscuit/fastener.rst
@@ -102,10 +102,10 @@ With the ``Biscuit`` in place, vacancies need to be cut out of each ``Panel``.
                 ])
 
                 # Move biscuit relative to altered part's local coordinates, then
-                # alter the part's local_obj.
+                # alter the part's obj.
                 for part in effected_parts:
                     biscuit_coordsys = biscuit.world_coords - part.world_coords
-                    part.local_obj = part.local_obj.cut(biscuit_coordsys + biscuit_cutter)
+                    part.obj = part.obj.cut(biscuit_coordsys + biscuit_cutter)
 
 
 Corner Assembly

--- a/docs-sphinx/cqparts_fasteners/easy-install/exact-fastener.rst
+++ b/docs-sphinx/cqparts_fasteners/easy-install/exact-fastener.rst
@@ -93,12 +93,12 @@ perfectly sized.
                 # screw : cut from all effected parts
                 for effect in self.evaluator.eval:
                     screw_coordsys = screw.world_coords - effect.part.world_coords
-                    effect.part.local_obj = effect.part.local_obj.cut(screw_coordsys + screw_cutter)
+                    effect.part.obj = effect.part.obj.cut(screw_coordsys + screw_cutter)
 
                 # anchor : all but last piece
                 for effect in self.evaluator.eval[:-1]:
                     anchor_coordsys = anchor.world_coords - effect.part.world_coords
-                    effect.part.local_obj = effect.part.local_obj.cut(anchor_coordsys + anchor_cutter)
+                    effect.part.obj = effect.part.obj.cut(anchor_coordsys + anchor_cutter)
 
 
 Using the Fastener

--- a/docs-sphinx/tutorials/assembly.rst
+++ b/docs-sphinx/tutorials/assembly.rst
@@ -291,12 +291,12 @@ We finally have all the parts we'll need, let's make our first *assembly*.
             axle = self.components['axle']
             left_wheel = self.components['left_wheel']
             right_wheel = self.components['right_wheel']
-            local_obj = part.local_obj
-            local_obj = local_obj \
+            obj = part.obj
+            obj = obj \
                 .cut((axle.world_coords - part.world_coords) + axle.get_cutout()) \
                 .cut((left_wheel.world_coords - part.world_coords) + left_wheel.get_cutout(self.wheel_clearance)) \
                 .cut((right_wheel.world_coords - part.world_coords) + right_wheel.get_cutout(self.wheel_clearance))
-            part.local_obj = local_obj
+            part.obj = obj
 
 **Parameters**
 

--- a/docs-sphinx/tutorials/part.rst
+++ b/docs-sphinx/tutorials/part.rst
@@ -38,7 +38,7 @@ Let's start with a simple variably sized rectangle.
     display(box)
 
 ``display`` will render the :class:`cadquery.Workplane` instance pulled from
-``box.local_obj``.
+``box.obj``.
 
 .. raw:: html
 
@@ -87,7 +87,7 @@ But wait... :mod:`cadquery` offers another way to achieve the same result::
         # ... (content as above)
         @property
         def mate_top(self):
-            plane = self.local_obj.faces(">Z").workplane().plane
+            plane = self.obj.faces(">Z").workplane().plane
             return Mate(self, CoordSystem.from_plane(plane))
 
     box = Box()
@@ -208,9 +208,9 @@ different wheels, then union them:
             wheel_l = Wheel(radius=self.l_radius, width=self.l_width)
             wheel_r = Wheel(radius=self.r_radius, width=self.r_width)
             # Union them with the axel solid
-            obj = obj.union(wheel_l.local_obj)
+            obj = obj.union(wheel_l.obj)
             obj = obj.union(
-                wheel_r.local_obj.mirror('XY') \
+                wheel_r.obj.mirror('XY') \
                     .translate((0, 0, self.axel_length))
             )
             return obj
@@ -218,13 +218,13 @@ different wheels, then union them:
     joined_wheel = JoinedWheel(
         r_radius=80, l_width=20, axel_diam=30,
     )
-    joined_wheel.local_obj
+    joined_wheel.obj
 
 ::
 
     display(joined_wheel)
 
-Note that we're instantiating 2 ``Wheel`` classes, and using their ``local_obj``
+Note that we're instantiating 2 ``Wheel`` classes, and using their ``obj``
 attributes to union with the axel.
 
 .. raw:: html

--- a/docs/doc/_static/iframes/asm-build-cycle/generate.py
+++ b/docs/doc/_static/iframes/asm-build-cycle/generate.py
@@ -104,7 +104,7 @@ class Thing(cqparts.Assembly):
         coords = self.components['cyl'].world_coords - self.components['pla'].world_coords
         # apply that to the "cutout" we want to subtract from the plate
         cutout = coords + self.components['cyl'].cutaway
-        self.components['pla'].local_obj = self.components['pla'].local_obj.cut(cutout)
+        self.components['pla'].obj = self.components['pla'].obj.cut(cutout)
 
 
 # -------------------------- Multiple Cycles --------------------------

--- a/docs/doc/_static/iframes/biscuit/generate.py
+++ b/docs/doc/_static/iframes/biscuit/generate.py
@@ -176,10 +176,10 @@ class BiscuitFastener(Fastener):
             ])
 
             # Move biscuit relative to altered part's local coordinates, then
-            # alter the part's local_obj.
+            # alter the part's obj.
             for part in effected_parts:
                 biscuit_coordsys = biscuit.world_coords - part.world_coords
-                part.local_obj = part.local_obj.cut(biscuit_coordsys + biscuit_cutter)
+                part.obj = part.obj.cut(biscuit_coordsys + biscuit_cutter)
 
 
 # ------------------- Corner Assembly -------------------

--- a/docs/doc/_static/iframes/easy-install/generate.py
+++ b/docs/doc/_static/iframes/easy-install/generate.py
@@ -327,12 +327,12 @@ class EasyInstallFastener(Fastener):
             # screw : cut from all effected parts
             for effect in self.evaluator.eval:
                 screw_coordsys = screw.world_coords - effect.part.world_coords
-                effect.part.local_obj = effect.part.local_obj.cut(screw_coordsys + screw_cutter)
+                effect.part.obj = effect.part.obj.cut(screw_coordsys + screw_cutter)
 
             # anchor : all but last piece
             for effect in self.evaluator.eval[:-1]:
                 anchor_coordsys = anchor.world_coords - effect.part.world_coords
-                effect.part.local_obj = effect.part.local_obj.cut(anchor_coordsys + anchor_cutter)
+                effect.part.obj = effect.part.obj.cut(anchor_coordsys + anchor_cutter)
 
 
 

--- a/docs/doc/_static/iframes/parts/generate.py
+++ b/docs/doc/_static/iframes/parts/generate.py
@@ -69,9 +69,9 @@ class JoinedWheel(cqparts.Part):
         wheel_l = Wheel(radius=self.l_radius, width=self.l_width)
         wheel_r = Wheel(radius=self.r_radius, width=self.r_width)
         # Union them with the axle solid
-        obj = obj.union(wheel_l.local_obj)
+        obj = obj.union(wheel_l.obj)
         obj = obj.union(
-            wheel_r.local_obj.mirror('XY') \
+            wheel_r.obj.mirror('XY') \
                 .translate((0, 0, self.axle_length))
         )
         return obj
@@ -79,7 +79,7 @@ class JoinedWheel(cqparts.Part):
 joined_wheel = JoinedWheel(
     r_radius=80, l_width=20, axle_diam=30,
 )
-joined_wheel.local_obj
+joined_wheel.obj
 
 
 # ------------------- Red Box -------------------

--- a/docs/doc/_static/iframes/toy-car/generate.py
+++ b/docs/doc/_static/iframes/toy-car/generate.py
@@ -140,12 +140,12 @@ class WheeledAxle(cqparts.Assembly):
         axle = self.components['axle']
         left_wheel = self.components['left_wheel']
         right_wheel = self.components['right_wheel']
-        local_obj = part.local_obj
-        local_obj = local_obj \
+        obj = part.obj
+        obj = obj \
             .cut((axle.world_coords - part.world_coords) + axle.get_cutout()) \
             .cut((left_wheel.world_coords - part.world_coords) + left_wheel.get_cutout(self.wheel_clearance)) \
             .cut((right_wheel.world_coords - part.world_coords) + right_wheel.get_cutout(self.wheel_clearance))
-        part.local_obj = local_obj
+        part.obj = obj
 
 
 # ------------------- Car Assembly -------------------

--- a/examples/fastener_easyinstall.py
+++ b/examples/fastener_easyinstall.py
@@ -105,8 +105,8 @@ vertical = Panel2()
 #   note: the vertical panel is built horizontally, **then** rotated upright.
 #         so we're finding the vector we want in it's local coordinates, then
 #         we're converting them to word coordinates to perform the evaluation.
-v_bot = vertical.local_obj.faces("<Z").workplane().plane
-v_top = vertical.local_obj.faces(">Z").workplane().plane
+v_bot = vertical.obj.faces("<Z").workplane().plane
+v_top = vertical.obj.faces(">Z").workplane().plane
 midpoint = (v_bot.origin + v_top.origin).multiply(0.5)
 
 # direction of bolt (normal to horizontal panel)

--- a/src/cqparts/codec/amf.py
+++ b/src/cqparts/codec/amf.py
@@ -26,7 +26,7 @@ class AMFExporter(Exporter):
     def __call__(self, filename='out.amf', world=False, tolerance=0.1):
 
         # Getting cadquery Shape
-        workplane = self.obj.world_obj if world else self.obj.local_obj
+        workplane = self.obj.world_obj if world else self.obj.obj
         shape = workplane.val()
 
         # call cadquery exporter

--- a/src/cqparts/codec/gltf.py
+++ b/src/cqparts/codec/gltf.py
@@ -487,7 +487,7 @@ class GLTFExporter(Exporter):
             )
         """
         with measure_time(log, 'buffers.part_mesh'):
-            workplane = part.local_obj  # cadquery.CQ instance
+            workplane = part.obj  # cadquery.CQ instance
             shape = workplane.val()  # expecting a cadquery.Solid instance
             tess = shape.tessellate(cls.tolerance)
             return tess

--- a/src/cqparts/codec/step.py
+++ b/src/cqparts/codec/step.py
@@ -29,7 +29,7 @@ class STEPExporter(Exporter):
     def __call__(self, filename='out.step', world=False):
 
         # Getting cadquery Shape
-        workplane = self.obj.world_obj if world else self.obj.local_obj
+        workplane = self.obj.world_obj if world else self.obj.obj
         shape = workplane.val()
 
         # call cadquery exporter

--- a/src/cqparts/codec/stl.py
+++ b/src/cqparts/codec/stl.py
@@ -27,7 +27,7 @@ class STLExporter(Exporter):
     def __call__(self, filename='out.stl', world=False, tolerance=0.1):
 
         # Getting cadquery Shape
-        workplane = self.obj.world_obj if world else self.obj.local_obj
+        workplane = self.obj.world_obj if world else self.obj.obj
         shape = workplane.val()
 
         # call cadquery exporter

--- a/src/cqparts/codec/svg.py
+++ b/src/cqparts/codec/svg.py
@@ -27,7 +27,7 @@ class SVGExporter(Exporter):
     def __call__(self, filename='out.svg', world=False):
 
         # Getting cadquery Shape
-        workplane = self.obj.world_obj if world else self.obj.local_obj
+        workplane = self.obj.world_obj if world else self.obj.obj
         shape = workplane.val()
 
         # call cadquery exporter

--- a/src/cqparts/codec/threejs_json.py
+++ b/src/cqparts/codec/threejs_json.py
@@ -67,7 +67,7 @@ class ThreejsJSONExporter(Exporter):
         """
         data = {}
         with StringIO() as stream:
-            obj = self.obj.world_obj if world else self.obj.local_obj
+            obj = self.obj.world_obj if world else self.obj.obj
             cadquery.exporters.exportShape(obj, 'TJS', stream)
             stream.seek(0)
             data = json.load(stream)

--- a/src/cqparts/component.py
+++ b/src/cqparts/component.py
@@ -109,3 +109,56 @@ class Component(ParametricObject):
         """
         from .codec import get_importer
         return get_importer(cls, importer_name)
+
+    class Placed(object):
+        """
+        A wrapper to a :class:`Component` to apply translation & rotation.
+        """
+
+        def __init__(self, wrapped, *args, **kwargs):
+            """
+            :param wrapped: wrapped component
+            :type wrapped: :class:`Component`
+            :param parent: parent :class:`PlacedComponent`
+            :type parent: :class:`PlacedComponent`
+            """
+            if not isinstance(component, Component):
+                raise ValueError("componnet must be a Component class, not a %r" % type(component))
+            self.wrapped = component
+
+            self.parent = kwargs.pop('parent', None)
+
+            # location, defaults to a coordinate system at the origin
+            self._coords = CoordSystem(*args, **kwargs)
+
+        def _placement_changed(self):
+            # called when:
+            #   - world_coords is set
+            # (intended to be overridden by inheriting classes)
+            pass
+
+        @property
+        def coords(self):
+            """
+            Component's placement in word coordinates
+            (:class:`CoordSystem <cqparts.utils.geometry.CoordSystem>`)
+
+            :return: coordinate system in the world, ``None`` if not set.
+            :rtype: :class:`CoordSystem <cqparts.utils.geometry.CoordSystem>`
+            """
+            return self._coords
+
+        @coords.setter
+        def coords(self, value):
+            if not isinstance(value, CoordSystem):
+                raise ValueError("set value must be a %r, not a %r" % (CoordSystem, type(value)))
+            self._coords = value
+            self._placement_changed()
+
+        @property
+        def obj(self):
+            return self.coords + self.wrapped.obj
+
+        # asm_ prefix as
+        asm_coords = coords
+        asm_obj = obj

--- a/src/cqparts/display/freecad.py
+++ b/src/cqparts/display/freecad.py
@@ -39,7 +39,7 @@ class FreeCADDisplayEnv(DisplayEnvironment):
                     show(obj.world_obj, obj._render.rgbt)
                 else:
                     # Part being displayed, just show in local coords
-                    show(obj.local_obj, obj._render.rgbt)
+                    show(obj.obj, obj._render.rgbt)
 
             elif isinstance(obj, Assembly):
                 obj.solve()

--- a/src/cqparts/part.py
+++ b/src/cqparts/part.py
@@ -28,7 +28,7 @@ class Part(Component):
         super(Part, self).__init__(*largs, **kwargs)
 
         # Initializing Instance State
-        self._local_obj = None
+        self._obj = None
         self._world_obj = None
 
     def make(self):
@@ -81,18 +81,18 @@ class Part(Component):
 
     def build(self, recursive=False):
         """
-        Building a part buffers the ``local_obj`` attribute.
+        Building a part buffers the ``obj`` attribute.
 
         Running ``.build()`` is optional, it's mostly used to test that
         there aren't any critical runtime issues with it's construction.
 
         :param recursive: (:class:`Part` has no children, parameter ignored)
         """
-        self.local_obj  # force object's construction, but don't do anything with it
+        self.obj  # force object's construction, but don't do anything with it
 
     # ----- Local Object
     @property
-    def local_obj(self):
+    def obj(self):
         """
         Buffered result of :meth:`make` which is (probably) a
         :class:`cadquery.Workplane` instance. If ``_simple`` is ``True``, then
@@ -105,7 +105,7 @@ class Part(Component):
             Only call :meth:`cqparts.Part.make` directly if you explicitly intend
             to re-generate the model from scratch, then dispose of it.
         """
-        if self._local_obj is None:
+        if self._obj is None:
             # Simplified or Complex
             if self._simple:
                 value = self.make_simple()
@@ -115,19 +115,19 @@ class Part(Component):
             if not isinstance(value, cadquery.CQ):
                 raise MakeError("invalid object type returned by make(): %r" % value)
             # Buffer object
-            self._local_obj = value
-        return self._local_obj
+            self._obj = value
+        return self._obj
 
-    @local_obj.setter
-    def local_obj(self, value):
-        self._local_obj = value
+    @obj.setter
+    def obj(self, value):
+        self._obj = value
         self._world_obj = None
 
     # ----- World Object
     @property
     def world_obj(self):
         """
-        The :meth:`local_obj <local_obj>` object in the
+        The :meth:`obj <obj>` object in the
         :meth:`world_coords <Component.world_coords>` coordinate system.
 
         .. note::
@@ -136,17 +136,17 @@ class Part(Component):
             :meth:`world_coords <Component.world_coords>` is not ``Null``.
         """
         if self._world_obj is None:
-            local_obj = self.local_obj
+            obj = self.obj
             world_coords = self.world_coords
-            if (local_obj is not None) and (world_coords is not None):
+            if (obj is not None) and (world_coords is not None):
                 # Copy local object, apply transform to move to its new home.
-                self._world_obj = world_coords + local_obj
+                self._world_obj = world_coords + obj
         return self._world_obj
 
     @world_obj.setter
     def world_obj(self, value):
         # implemented just for this helpful message
-        raise ValueError("can't set world_obj directly, set local_obj instead")
+        raise ValueError("can't set world_obj directly, set obj instead")
 
     @property
     def bounding_box(self):
@@ -156,7 +156,7 @@ class Part(Component):
         :return: bounding box of part
         :rtype: cadquery.BoundBox
         """
-        return self.local_obj.findSolid().BoundingBox()
+        return self.obj.findSolid().BoundingBox()
 
     def _placement_changed(self):
         self._world_obj = None

--- a/src/cqparts/utils/test.py
+++ b/src/cqparts/utils/test.py
@@ -36,7 +36,7 @@ class ComponentTest(unittest.TestCase):
         self.assertGreater(obj.bounding_box.DiagonalLength, 0)
 
     def assertPartHasVolume(self, obj):
-        self.assertGreater(obj.local_obj.val().wrapped.Volume, 0)  # has volume
+        self.assertGreater(obj.obj.val().wrapped.Volume, 0)  # has volume
 
     def assertAssembyHasComponents(self, obj):
         self.assertGreater(len(obj.components), 0)  # has components

--- a/src/cqparts_fasteners/fasteners/nutbolt.py
+++ b/src/cqparts_fasteners/fasteners/nutbolt.py
@@ -56,8 +56,8 @@ class NutAndBoltFastener(Fastener):
             for effect in self.evaluator.eval:
                 # bolt
                 bolt_coordsys = bolt.world_coords - effect.part.world_coords
-                effect.part.local_obj = effect.part.local_obj.cut(bolt_coordsys + bolt_cutter)
+                effect.part.obj = effect.part.obj.cut(bolt_coordsys + bolt_cutter)
 
                 # nut
                 nut_coordsys = nut.world_coords - effect.part.world_coords
-                effect.part.local_obj = effect.part.local_obj.cut(nut_coordsys + nut_cutter)
+                effect.part.obj = effect.part.obj.cut(nut_coordsys + nut_cutter)

--- a/src/cqparts_fasteners/fasteners/screw.py
+++ b/src/cqparts_fasteners/fasteners/screw.py
@@ -49,4 +49,4 @@ class ScrewFastener(Fastener):
             for effect in self.evaluator.eval:
                 relative_coordsys = screw.world_coords - effect.part.world_coords
                 local_cutter = relative_coordsys + cutter
-                effect.part.local_obj = effect.part.local_obj.cut(local_cutter)
+                effect.part.obj = effect.part.obj.cut(local_cutter)

--- a/src/cqparts_fasteners/female.py
+++ b/src/cqparts_fasteners/female.py
@@ -81,7 +81,7 @@ class FemaleFastenerPart(DrivenFastenerHead):
         # resides on the opposite side of the XY plane
 
         # Cut thread
-        thread = self.thread.local_obj.translate((0, 0, -self.height))
+        thread = self.thread.obj.translate((0, 0, -self.height))
         nut = nut.cut(thread)
         return nut
 

--- a/src/cqparts_fasteners/male.py
+++ b/src/cqparts_fasteners/male.py
@@ -175,7 +175,7 @@ class MaleFastenerPart(cqparts.Part):
         # (change thread's length before building... not the typical flow, but
         #  it works all the same)
         self.thread.length = (self.length - self.neck_length) + thread_offset
-        self.local_obj = None  # clear to force build after parameter change
+        self.obj = None  # clear to force build after parameter change
 
     def make(self):
         # build Head
@@ -208,7 +208,7 @@ class MaleFastenerPart(cqparts.Part):
                 obj = obj.union(neck_taper)
 
         # build thread
-        thread = self.thread.local_obj.translate((0, 0, -self.length))
+        thread = self.thread.obj.translate((0, 0, -self.length))
         obj = obj.union(thread)
 
         # Sharpen to a point

--- a/src/cqparts_fasteners/utils/evaluator.py
+++ b/src/cqparts_fasteners/utils/evaluator.py
@@ -220,8 +220,8 @@ class VectorEvaluator(Evaluator):
         #   - return the maximum of these from all solids
         def max_length_iter():
             for part in self.parts:
-                if part.local_obj.findSolid():
-                    bb = part.local_obj.findSolid().BoundingBox()
+                if part.obj.findSolid():
+                    bb = part.obj.findSolid().BoundingBox()
                     yield abs(bb.center - self.location.origin) + (bb.DiagonalLength / 2)
         try:
             return max(max_length_iter())

--- a/src/cqparts_motors/stepper.py
+++ b/src/cqparts_motors/stepper.py
@@ -199,8 +199,8 @@ class Stepper(motor.Motor):
         " shaft cutout "
         stepper_shaft = self.components['shaft']
         top = self.components['topcap']
-        local_obj = top.local_obj
-        local_obj = local_obj.cut(stepper_shaft.get_cutout(clearance=0.5))
+        obj = top.obj
+        obj = obj.cut(stepper_shaft.get_cutout(clearance=0.5))
 
     def make_alterations(self):
         self.apply_cutout()

--- a/tests/manual/block_tree.py
+++ b/tests/manual/block_tree.py
@@ -74,7 +74,7 @@ class Branch(cqparts.Part):
     def mate_top(self):
         # Mate point at the top of the cylinder, twist applied
         return Mate(self, CoordSystem.from_plane(
-            self.local_obj.faces(">Z").workplane().plane.rotated((0, 0, self.twist))
+            self.obj.faces(">Z").workplane().plane.rotated((0, 0, self.twist))
         ))
 
 
@@ -114,7 +114,7 @@ class Splitter(cqparts.Part):
     @property
     def mate_left(self):
         """Mate point in the center of the angled face on the left"""
-        # TODO: query self.local_obj geometry to get center of face?
+        # TODO: query self.obj geometry to get center of face?
         return Mate(self, CoordSystem(
             origin=(-self.width / 4, 0, (self.height + self.left_wall_height) / 2),
             xDir=(0,1,0),
@@ -124,7 +124,7 @@ class Splitter(cqparts.Part):
     @property
     def mate_right(self):
         """Mate point in the center of the angled face on the right"""
-        # TODO: query self.local_obj geometry to get center of face?
+        # TODO: query self.obj geometry to get center of face?
         return Mate(self, CoordSystem(
             origin=(self.width / 4, 0, (self.height + self.right_wall_height) / 2),
             xDir=(0,1,0),

--- a/tests/manual/threads.py
+++ b/tests/manual/threads.py
@@ -58,7 +58,7 @@ else:
     if env_name == 'freecad':
         # force complex thread
         from Helpers import show
-        show(thread.local_obj)
+        show(thread.obj)
         show(thread.profile)
 
     else:

--- a/tests/t_cqparts/test_codecs.py
+++ b/tests/t_cqparts/test_codecs.py
@@ -200,7 +200,7 @@ class TestStep(CodecFileTest):
         # exception not raised before object is formed
         with self.assertRaises(ValueError):
             with suppress_stdout_stderr():
-                thing.local_obj
+                thing.obj
 
     def test_multipart_part(self):
         # When imported as a Part, geometry is unioned together

--- a/tests/t_cqparts/test_display.py
+++ b/tests/t_cqparts/test_display.py
@@ -56,7 +56,7 @@ class FreeCADTests(CQPartsTest):
         part = Box()
         disp_env = display.freecad.FreeCADDisplayEnv()
         disp_env.display(part)
-        mock_show.assert_called_once_with(part.local_obj, (192, 192, 192, 0))
+        mock_show.assert_called_once_with(part.obj, (192, 192, 192, 0))
 
     @patch_forgiving('Helpers.show')
     def test_assembly(self, mock_show):

--- a/tests/t_cqparts/test_part.py
+++ b/tests/t_cqparts/test_part.py
@@ -20,7 +20,7 @@ class PreMaturePartTests(CQPartsTest):
             pass  # no content
 
         with self.assertRaises(NotImplementedError):
-            P().local_obj
+            P().obj
 
     def test_bad_make(self):
         class P(cqparts.Part):
@@ -28,7 +28,7 @@ class PreMaturePartTests(CQPartsTest):
                 return 1
 
         with self.assertRaises(MakeError):
-            P().local_obj
+            P().obj
 
 
 class MakeSimpleTests(CQPartsTest):
@@ -40,10 +40,10 @@ class MakeSimpleTests(CQPartsTest):
 
         # complex part
         p_complex = P()
-        cbb = p_complex.local_obj.val().BoundingBox()  # complex geometry
+        cbb = p_complex.obj.val().BoundingBox()  # complex geometry
         # simplified part
         p_simple = P(_simple=True)
-        sbb = p_simple.local_obj.val().BoundingBox()  # simplified geometry
+        sbb = p_simple.obj.val().BoundingBox()  # simplified geometry
 
         self.assertAlmostEqual(cbb.xmin, sbb.xmin)
         self.assertAlmostEqual(cbb.xmax, sbb.xmax)
@@ -60,11 +60,11 @@ class MakeSimpleTests(CQPartsTest):
                 return cadquery.Workplane('XY').box(10,10,10)  # big box
 
         # complex geometry yields unit cube
-        cbb = P().local_obj.val().BoundingBox()
+        cbb = P().obj.val().BoundingBox()
         self.assertAlmostEqual((cbb.xmin, cbb.xmax), (-0.5, 0.5))
 
         # complex geometry yields cube with 10xunit sides
-        sbb = P(_simple=True).local_obj.val().BoundingBox()
+        sbb = P(_simple=True).obj.val().BoundingBox()
         self.assertAlmostEqual((sbb.xmin, sbb.xmax), (-5, 5))
 
 
@@ -104,7 +104,7 @@ class BuildCycleTests(CQPartsTest):
         with self.assertRaises(ValueError):
             p.world_obj = 'value is irrelevant'
 
-    def test_set_local_obj(self):
+    def test_set_obj(self):
         class P(cqparts.Part):
             def make(self):
                 return cadquery.Workplane('XY').box(1, 1, 1)
@@ -116,7 +116,7 @@ class BuildCycleTests(CQPartsTest):
         self.assertAlmostEqual((bb.zmin, bb.zmax), (-0.5 + 10, 0.5 + 10))
 
         # change local
-        p.local_obj = cadquery.Workplane('XY').box(10, 10, 10)
+        p.obj = cadquery.Workplane('XY').box(10, 10, 10)
         bb = p.world_obj.val().BoundingBox()
         self.assertAlmostEqual(bb.DiagonalLength, sqrt(3) * 10)
         self.assertAlmostEqual((bb.zmin, bb.zmax), (-5 + 10, 5 + 10))

--- a/tests/t_cqparts/test_wrappers.py
+++ b/tests/t_cqparts/test_wrappers.py
@@ -18,4 +18,4 @@ class TestAsPart(CQPartsTest):
 
         box = Box()
         self.assertIsInstance(box, cqparts.Part)
-        self.assertIsInstance(box.local_obj, cadquery.Workplane)
+        self.assertIsInstance(box.obj, cadquery.Workplane)


### PR DESCRIPTION
Removed any _world_ presence from `Component`, `Part`, and `Assembly` class instances.
All _world_ coordinate systems and geometry will be set in a wrapper by each component's parent `Assembly`.